### PR TITLE
Update model prediction caching to lock for less time.

### DIFF
--- a/lit_nlp/api/model.py
+++ b/lit_nlp/api/model.py
@@ -106,6 +106,18 @@ class Model(metaclass=abc.ABCMeta):
     """Maximum minibatch size for this model."""
     return 1
 
+  @property
+  def supports_concurrent_predictions(self):
+    """Indcates support for multiple concurrent predict calls across threads.
+
+    Defaults to false.
+
+    Returns:
+      (bool) True if the model can handle multiple concurrent calls to its
+      `predict_minibatch` method.
+    """
+    return False
+
   @abc.abstractmethod
   def predict_minibatch(self, inputs: List[JsonDict]) -> List[JsonDict]:
     """Run prediction on a batch of inputs.
@@ -239,6 +251,10 @@ class ModelWrapper(Model):
   def max_minibatch_size(self) -> int:
     return self.wrapped.max_minibatch_size()
 
+  @property
+  def supports_concurrent_predictions(self):
+    return self.wrapped.supports_concurrent_predictions
+
   def predict_minibatch(self, inputs: List[JsonDict], **kw) -> List[JsonDict]:
     return self.wrapped.predict_minibatch(inputs, **kw)
 
@@ -306,6 +322,11 @@ class BatchedRemoteModel(Model):
   def max_minibatch_size(self) -> int:
     """Maximum minibatch size for this model. Subclass can override this."""
     return 1
+
+  @property
+  def supports_concurrent_predictions(self):
+    """Remote models can handle concurrent predictions by default."""
+    return True
 
   @abc.abstractmethod
   def predict_minibatch(self, inputs: List[JsonDict]) -> List[JsonDict]:

--- a/lit_nlp/lib/caching_test.py
+++ b/lit_nlp/lib/caching_test.py
@@ -54,6 +54,7 @@ class CachingTest(absltest.TestCase):
     results = wrapper.predict_with_metadata(examples, "dataset")
     self.assertEqual(1, model.count)
     self.assertEqual({"score": 1}, results[0])
+    self.assertEmpty(wrapper._cache._pred_locks)
 
   def test_caching_model_wrapper_not_cached(self):
     model = testing_utils.TestIdentityRegressionModel()
@@ -100,6 +101,64 @@ class CachingTest(absltest.TestCase):
     self.assertEqual({"score": 0}, results[0])
     self.assertEqual({"score": 1}, results[1])
     self.assertEqual({"score": 2}, results[2])
+
+  def test_pred_lock_key(self):
+    cache = caching.PredsCache()
+    cache_key = [("a", "1"), ("a", "2")]
+
+    self.assertIsNone(cache.pred_lock_key(cache_key))
+
+    cache.get_pred_lock(cache_key)
+    expected_cache_key = frozenset(cache_key)
+    self.assertEqual(expected_cache_key, cache.pred_lock_key(cache_key))
+
+    sub_cache_key = [("a", "1")]
+    self.assertEqual(expected_cache_key, cache.pred_lock_key(sub_cache_key))
+
+    mismatch_cache_key = [("b", "1")]
+    self.assertIsNone(cache.pred_lock_key(mismatch_cache_key))
+
+  def test_pred_lock_key_no_concurrent_predictions(self):
+    cache = caching.PredsCache(False)
+    cache_key = [("a", "1"), ("a", "2")]
+
+    self.assertIsNone(cache.pred_lock_key(cache_key))
+
+    cache.get_pred_lock(cache_key)
+    expected_cache_key = frozenset(
+        [caching.PRED_LOCK_KEY_WHEN_NO_CONCURRENT_ACCESS])
+    self.assertEqual(expected_cache_key, cache.pred_lock_key(cache_key))
+
+    sub_cache_key = [("a", "1")]
+    self.assertEqual(expected_cache_key, cache.pred_lock_key(sub_cache_key))
+
+    mismatch_cache_key = [("b", "1")]
+    self.assertEqual(expected_cache_key, cache.pred_lock_key(
+        mismatch_cache_key))
+
+  def test_delete_pred_lock(self):
+    cache = caching.PredsCache()
+    cache_key = [("a", "1"), ("a", "2")]
+
+    self.assertIsNone(cache.delete_pred_lock(cache_key))
+
+    lock = cache.get_pred_lock(cache_key)
+    self.assertEqual(lock, cache.delete_pred_lock(cache_key))
+
+    self.assertIsNone(cache.delete_pred_lock(cache_key))
+
+  def test_get_pred_lock(self):
+    cache = caching.PredsCache()
+    cache_key = [("a", "1"), ("a", "2")]
+
+    lock = cache.get_pred_lock(cache_key)
+    self.assertIsNotNone(lock)
+
+    sub_cache_key = [("a", "2")]
+    self.assertEqual(lock, cache.get_pred_lock(sub_cache_key))
+
+    mismatch_cache_key = [("b", "2")]
+    self.assertNotEqual(lock, cache.get_pred_lock(mismatch_cache_key))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Only hold single model cache lock when reading or writing the cache.
- No longer hold that lock when calling a model on a cache miss.
- Create a map of a "model prediction" locks, one per each set of inputs needing a model prediction call. This avoids duplicate calls to models (for example for whole dataset, or for a single selected example) without holding the single cache lock.

PiperOrigin-RevId: 456243578