### PR TITLE
Use more sensible default values for settings in the clustering module.

### DIFF
--- a/lit_nlp/components/salience_clustering.py
+++ b/lit_nlp/components/salience_clustering.py
@@ -268,9 +268,9 @@ class SalienceClustering(lit_components.Interpreter):
             types.CategoryLabel(
                 required=True, vocab=list(self.salience_mappers.keys())),
         N_CLUSTERS_KEY:
-            types.Scalar(min_val=2, max_val=25, default=2, step=1),
+            types.Scalar(min_val=2, max_val=100, default=10, step=1),
         N_TOP_TOKENS_KEY:
-            types.Scalar(min_val=1, max_val=100, default=10, step=1),
+            types.Scalar(min_val=1, max_val=20, default=5, step=1),
         SEED_KEY:
             types.TextSegment(default='0'),
     }


### PR DESCRIPTION
Looking at 100 top tokens isn't helpful in understanding what a cluster resembles. Therefore, we're allowing only a smaller number.

Since the goal of clustering is to find patterns in the dataset we will likely want to dissect the dataset into smaller rather than bigger portions. Because, we anticipate small subsets of data having a bias/unwanted artifact. Therefore, we're increasing the number of maximum clusters.

PiperOrigin-RevId: 459280564